### PR TITLE
[PLUGIN-1617] Fix python native mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- version properties -->
-    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
-    <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
+    <cdap.version>6.10.0-SNAPSHOT</cdap.version>
+    <hydrator.version>2.12.0-SNAPSHOT</hydrator.version>
     <junit.version>4.11</junit.version>
     <jython.version>2.5.2</jython.version>
     <py4j.version>0.10.8.1</py4j.version>
@@ -109,7 +109,7 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline</artifactId>
+      <artifactId>cdap-data-pipeline3_2.12</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/main/resources/pythonEvaluator.py
+++ b/src/main/resources/pythonEvaluator.py
@@ -50,7 +50,7 @@ server_ssl_context.load_cert_chain(key_file, password='')
 
 # address must match cert, because we're checking hostnames
 gateway_parameters = GatewayParameters(
-  address='localhost',
+  address='127.0.0.1',
   ssl_context=client_ssl_context)
 
 transform_transport = PythonTransformTransportImpl()

--- a/src/test/java/io/cdap/plugin/python/transform/PythonTransformNativeTest.java
+++ b/src/test/java/io/cdap/plugin/python/transform/PythonTransformNativeTest.java
@@ -17,14 +17,27 @@
 package io.cdap.plugin.python.transform;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -61,5 +74,31 @@ public class PythonTransformNativeTest extends BasePythonTransformTest {
     List<StructuredRecord> outputRecords = runPythonEvaluatorPipeline(INPUT_DEFAULT, properties);
 
     Assert.assertEquals(new HashSet<>(outputRecords), new HashSet<>(INPUT_DEFAULT));
+  }
+
+  @Test
+  public void testSSLCertificateGeneration() throws UnrecoverableKeyException, CertificateException,
+          NoSuchAlgorithmException, KeyStoreException, IOException {
+    KeyStore ks = KeyStores.generatedCertKeyStore(10, "password");
+    File pemFile = temporaryFolder.newFile("selfsigned.pem");
+    KeyStores.generatePemFileFromKeyStore(ks, "password", pemFile);
+
+    List<String> certFile = Files.readLines(pemFile, StandardCharsets.UTF_8);
+    certFile.removeIf(String::isEmpty);
+    // should contain 6 lines
+    // -----BEGIN RSA PRIVATE KEY-----\n <encoded private key>\n -----END RSA PRIVATE KEY-----\n
+    // -----BEGIN CERTIFICATE-----\n <encoded public key>\n -----END CERTIFICATE-----
+    Assert.assertEquals(6, certFile.size());
+    byte [] decodedPublicKey = Base64.getDecoder().decode(certFile.get(4));
+    X509Certificate cert = (X509Certificate) CertificateFactory.getInstance("X.509")
+            .generateCertificate(new ByteArrayInputStream(decodedPublicKey));
+
+    Collection<List<?>> sans = cert.getSubjectAlternativeNames();
+    // Should contain only 1 san (ip: 127.0.0.1)
+    Assert.assertEquals(1, sans.size());
+    Integer sanType = (Integer) ((List<?>) sans.toArray()[0]).get(0);
+    Assert.assertEquals((Integer) 7, sanType); // Enum for IPAddress
+    String sanValue = (String) ((List<?>) sans.toArray()[0]).get(1);
+    Assert.assertEquals("127.0.0.1", sanValue);
   }
 }


### PR DESCRIPTION
https://cdap.atlassian.net/browse/PLUGIN-1617
- Fix classloader issue.
- Fix SSL certificate issue.
- Upgrade cdap and hydrator plugins version.
- Use `127.0.0.1` in pythonEvaluator.py instead of `localhost` because `localhost` can be binded to ipv6 and java gateway server to ipv4 depending on the env which causes the connection from python to java being refused.