### PR TITLE
[🍒][PLUGIN-1869] Update deprecated PROTOCOL_TLSv1

### DIFF
--- a/src/main/resources/pythonEvaluator.py
+++ b/src/main/resources/pythonEvaluator.py
@@ -40,12 +40,12 @@ ${cdap.transform.function}
 
 key_file = "selfsigned.pem"
 
-client_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+client_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 client_ssl_context.verify_mode = ssl.CERT_REQUIRED
 client_ssl_context.check_hostname = True
 client_ssl_context.load_verify_locations(cafile=key_file)
 
-server_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+server_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
 server_ssl_context.load_cert_chain(key_file, password='')
 
 # address must match cert, because we're checking hostnames


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - 401d8ee7a97339f562f90b82856da3a42c565e99

### PR:
 - #30 [ Reviewer @itsankit-google ]
 
 ---
 
 ## Description
Jira : [PLUGIN-1869](https://cdap.atlassian.net/browse/PLUGIN-1869)

As per [python docs](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLSv1)  
> OpenSSL has deprecated all version specific protocols.

A simple python pipeline running in *native mode* in dataproc (2.0) with python 3.8, starts to fail in newer dataproc (2.1 and above) with python 3.10, we see the following error log.

### Test
- This fix has been tested on dataproc 2.0 / 2.1 / 2.2, pipeline works as expected.

```
2025-03-05 09:12:49,107 - ERROR [Executor task launch worker for task 0.0 in stage 0.0 (TID 0):o.a.s.u.Utils@98] - Aborting task
java.util.concurrent.ExecutionException: Error when transforming stage Python: com.google.common.util.concurrent.UncheckedExecutionException: io.cdap.cdap.api.exception.WrappedStageException: Stage 'Python' encountered : java.lang.RuntimeException: Connection to python process failed in 120 seconds.
/hadoop/yarn/nm-local-dir/usercache/yarn/appcache/application_1740807003160_0006/container_1740807003160_0006_01_000002/tmp/transform2627900996459733583/transform.py:48: DeprecationWarning: ssl.PROTOCOL_TLSv1 is deprecated
  client_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
/hadoop/yarn/nm-local-dir/usercache/yarn/appcache/application_1740807003160_0006/container_1740807003160_0006_01_000002/tmp/transform2627900996459733583/transform.py:53: DeprecationWarning: ssl.PROTOCOL_TLSv1 is deprecated
  server_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)

	at io.cdap.cdap.etl.spark.function.TransformFunction.call(TransformFunction.java:61)
	at org.apache.spark.api.java.JavaRDDLike.$anonfun$flatMap$1(JavaRDDLike.scala:125)
	at scala.collection.Iterator$$anon$11.nextCur(Iterator.scala:486)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:492)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:491)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:491)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$executeTask$1(SparkHadoopWriter.scala:136)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1539)
	at org.apache.spark.internal.io.SparkHadoopWriter$.executeTask(SparkHadoopWriter.scala:135)
	at org.apache.spark.internal.io.SparkHadoopWriter$.$anonfun$write$1(SparkHadoopWriter.scala:88)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:136)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:548)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1505)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:551)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.lang.Thread.run(Thread.java:829)
Caused by: com.google.common.util.concurrent.UncheckedExecutionException: io.cdap.cdap.api.exception.WrappedStageException: Stage 'Python' encountered : java.lang.RuntimeException: Connection to python process failed in 120 seconds.
/hadoop/yarn/nm-local-dir/usercache/yarn/appcache/application_1740807003160_0006/container_1740807003160_0006_01_000002/tmp/transform2627900996459733583/transform.py:48: DeprecationWarning: ssl.PROTOCOL_TLSv1 is deprecated
  client_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
/hadoop/yarn/nm-local-dir/usercache/yarn/appcache/application_1740807003160_0006/container_1740807003160_0006_01_000002/tmp/transform2627900996459733583/transform.py:53: DeprecationWarning: ssl.PROTOCOL_TLSv1 is deprecated
  server_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)

	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2258)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3990)
	at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4793)
	at io.cdap.cdap.etl.spark.function.FunctionCache$EnabledCache.getValue(FunctionCache.java:122)
	at io.cdap.cdap.etl.spark.function.PluginFunctionContext.createAndInitializePlugin(PluginFunctionContext.java:105)
	at io.cdap.cdap.etl.spark.function.PluginFunctionContext.createAndInitializePlugin(PluginFunctionContext.java:114)
	at io.cdap.cdap.etl.spark.function.TransformFunction.call(TransformFunction.java:49)
	... 17 common frames omitted
Caused by: io.cdap.cdap.api.exception.WrappedStageException: Stage 'Python' encountered : java.lang.RuntimeException: Connection to python process failed in 120 seconds.
/hadoop/yarn/nm-local-dir/usercache/yarn/appcache/application_1740807003160_0006/container_1740807003160_0006_01_000002/tmp/transform2627900996459733583/transform.py:48: DeprecationWarning: ssl.PROTOCOL_TLSv1 is deprecated
  client_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
/hadoop/yarn/nm-local-dir/usercache/yarn/appcache/application_1740807003160_0006/container_1740807003160_0006_01_000002/tmp/transform2627900996459733583/transform.py:53: DeprecationWarning: ssl.PROTOCOL_TLSv1 is deprecated
  server_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)

	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:64)
	at io.cdap.cdap.etl.common.plugin.StageLoggingCaller.call(StageLoggingCaller.java:40)
	at io.cdap.cdap.etl.common.plugin.WrappedTransform.initialize(WrappedTransform.java:73)
	at io.cdap.cdap.etl.common.plugin.WrappedTransform.initialize(WrappedTransform.java:33)
	at io.cdap.cdap.etl.spark.function.PluginFunctionContext.lambda$createAndInitializePlugin$0(PluginFunctionContext.java:107)
	at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4796)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3589)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2374)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2337)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2252)
	... 23 common frames omitted
Caused by: java.lang.RuntimeException: Connection to python process failed in 120 seconds.
/hadoop/yarn/nm-local-dir/usercache/yarn/appcache/application_1740807003160_0006/container_1740807003160_0006_01_000002/tmp/transform2627900996459733583/transform.py:48: DeprecationWarning: ssl.PROTOCOL_TLSv1 is deprecated
  client_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
/hadoop/yarn/nm-local-dir/usercache/yarn/appcache/application_1740807003160_0006/container_1740807003160_0006_01_000002/tmp/transform2627900996459733583/transform.py:53: DeprecationWarning: ssl.PROTOCOL_TLSv1 is deprecated
  server_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)

	at io.cdap.plugin.python.transform.Py4jPythonExecutor.initialize(Py4jPythonExecutor.java:221)
	at io.cdap.plugin.python.transform.PythonEvaluator.initialize(PythonEvaluator.java:168)
	at io.cdap.cdap.etl.common.plugin.WrappedTransform.lambda$initialize$3(WrappedTransform.java:74)
	at io.cdap.cdap.etl.common.plugin.Caller$1.call(Caller.java:30)
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:62)
	... 32 common frames omitted
```




[PLUGIN-1869]: https://cdap.atlassian.net/browse/PLUGIN-1869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
 
 
 