### PR TITLE
Remove SNAPSHOT for 2.3.2 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <name>Python plugins</name>
   <groupId>io.cdap.plugin</groupId>
   <artifactId>python-plugins</artifactId>
-  <version>2.3.2-SNAPSHOT</version>
+  <version>2.3.2</version>
   <packaging>jar</packaging>
 
 


### PR DESCRIPTION
Remove SNAPSHOT for 2.3.2 release